### PR TITLE
feat: Implement public user registration endpoint

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,19 +1,51 @@
-import { Controller, Post, Body } from '@nestjs/common';
+import { Controller, Post, Body, ConflictException, HttpStatus } from '@nestjs/common';
 import { ApiTags, ApiResponse } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
 import { Public } from '../../commons/decorators/public.decorator';
+import { UsersService } from '../users/users.service';
+import { CreateUserDto } from '../users/dto/create-user.dto';
+import { Role } from '../../commons/enums/role.enum';
+import { PublicRegisterUserDto } from './dto/public-register-user.dto';
+import { User } from '../users/entities/user.entity';
 
 @ApiTags('Auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly usersService: UsersService, // Add this
+  ) {}
 
   @Post('login')
-  @Public() // Add this line
-  @ApiResponse({ status: 200, description: 'User successfully logged in.' })
-  @ApiResponse({ status: 401, description: 'Invalid credentials.' })
+  @Public()
+  @ApiResponse({ status: HttpStatus.OK, description: 'User successfully logged in.' })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Invalid credentials.' })
   login(@Body() loginDto: LoginDto) {
     return this.authService.login(loginDto);
+  }
+
+  @Post('register')
+  @Public()
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'User successfully registered.', type: User }) // Assuming User entity is returned (without password)
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid input data.' })
+  @ApiResponse({ status: HttpStatus.CONFLICT, description: 'Email or phone already exists.' })
+  async register(@Body() publicRegisterUserDto: PublicRegisterUserDto): Promise<Omit<User, 'password'>> {
+    const createUserDto: CreateUserDto = {
+      ...publicRegisterUserDto,
+      role: Role.User, // Set default role
+    };
+    try {
+      const user = await this.usersService.createUser(createUserDto);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { password, ...result } = user;
+      return result;
+    } catch (error) {
+      if (error instanceof ConflictException) {
+        throw new ConflictException(error.message);
+      }
+      // Handle other errors or rethrow
+      throw error;
+    }
   }
 }

--- a/src/modules/auth/dto/public-register-user.dto.ts
+++ b/src/modules/auth/dto/public-register-user.dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsEmail,
+  IsNotEmpty,
+  IsString,
+  IsPhoneNumber,
+  IsOptional,
+  MinLength, // Example: Add password complexity
+} from 'class-validator';
+
+export class PublicRegisterUserDto {
+  @ApiProperty({ description: 'Full name of the user', example: 'John Doe' })
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+
+  @ApiProperty({ description: 'Email address of the user', example: 'john.doe@example.com' })
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({
+    description: 'Password for the user account (min 8 characters)',
+    example: 'Str0ngP@sswOrd',
+  })
+  @IsNotEmpty()
+  @IsString()
+  @MinLength(8) // Added for basic password strength
+  password: string;
+
+  @ApiProperty({
+    description: 'Phone number of the user (Malian format)',
+    example: '70000000',
+    required: false,
+  })
+  @IsOptional()
+  @IsPhoneNumber('ML', { message: 'Phone number must be a valid Malian phone number.' })
+  phone?: string;
+}


### PR DESCRIPTION
Adds a new public endpoint for user registration at POST /auth/register.

Key changes:
- Created `PublicRegisterUserDto` which omits the 'role' field, ensuring
  users cannot specify a role during public sign-up. It includes fields
  for name, email, password (with minLength validation), and an optional phone number.
- Added a `register` method to `AuthController`:
    - Decorated with `@Public()` to allow unauthenticated access.
    - Uses `PublicRegisterUserDto` for input validation.
    - Explicitly sets the `role` to `Role.User` for new registrations.
    - Calls `UsersService.createUser` to persist the new user.
    - Returns the created user (excluding password) in the response.
    - Handles potential `ConflictException` if email/phone already exists.
- `AuthController` now injects `UsersService`. `AuthModule` already
  provided `UsersService`, though a future refactor to import `UsersModule`
  into `AuthModule` is recommended for better modularity.

The existing `POST /users` endpoint in `UsersController` remains the
admin-only route for creating users with specified roles.